### PR TITLE
Fixes #4423 - Getter on mutations size

### DIFF
--- a/google-cloud-clients/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UpdateBuilder.java
+++ b/google-cloud-clients/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UpdateBuilder.java
@@ -664,4 +664,9 @@ public abstract class UpdateBuilder<T extends UpdateBuilder> {
   boolean isEmpty() {
     return mutations.isEmpty();
   }
+  
+  /** Get the number of mutations. */
+  public int getMutationsSize() {
+    return mutations.size();
+  }
 }


### PR DESCRIPTION
Getter over mutations size
Allow knowing the size of the list. For exemple, the batch size is limited to 500 mutations

Fixes #4423